### PR TITLE
Add option for dumping the server output

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -50,7 +50,8 @@ class ModelBenchmark:
         temperature: float = 0.6,
         top_p: float = 0.95,
         max_tokens: int = 128,
-        verbose=False
+        verbose=False,
+        dump_server_output: bool = False
     ):
         if backend not in ("tgi", "mii", "sglang", "vllm", "lmdeploy"):
             raise ValueError(f"Unsupported backend: {backend}. Supported backends are: tgi, mii, sglang, vllm, lmdeploy.")
@@ -60,6 +61,7 @@ class ModelBenchmark:
         self.model_size = 0
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.verbose = verbose
+        self.dump_server_output = dump_server_output
         self.iec = InferenceEngineClient()
         self.api = HfApi()
         self.temperature = temperature
@@ -236,7 +238,7 @@ class ModelBenchmark:
 
         # ── First launch: cold start ──────────────────────────────
         t0 = time.time()
-        self.iec.launch(backend=self.backend, model=self.model_path)
+        self.iec.launch(backend=self.backend, model=self.model_path, dump_server_output=self.dump_server_output)
         startup = time.time() - t0
 
         # optional warm-up

--- a/benchmark/inference_engine_client.py
+++ b/benchmark/inference_engine_client.py
@@ -21,7 +21,7 @@ class InferenceEngineClient:
 
     
 
-    def launch(self, backend: str, model: str, timeout: float = 500.0):
+    def launch(self, backend: str, model: str, timeout: float = 500.0, dump_server_output: bool = False):
         """
         1) Starts your existing launch_engine.sh in a Popen (non-blocking).
         2) Polls `http://127.0.0.1:23333/v1/models` every 2 seconds
@@ -52,7 +52,7 @@ class InferenceEngineClient:
         )
 
         # Start a daemon thread to read the launcher output
-        _start_log_tailer(self, max_lines=10)
+        _start_log_tailer(self, max_lines=10, dump_server_output=dump_server_output)
 
         # 2) Poll /v1/models until our model_id appears or timeout.
         list_url = "http://127.0.0.1:23333/v1/models"

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -70,13 +70,15 @@ def clean_prediction(prediction: list[str]) -> list[str]:
     return cleaned
 
 
-def _start_log_tailer(self, max_lines: int = 30):
+def _start_log_tailer(self, max_lines: int = 30, dump_server_output: bool = False):
     """Spawn a daemon thread that reads the process’ output and
     stores the latest `max_lines` in self._log_buf (deque[str])."""
     self._log_buf = deque(maxlen=max_lines)
 
     def _tail():
         for line in self._launcher_proc.stdout:
+            if dump_server_output:
+                print(line)
             self._log_buf.append(line.rstrip("\n"))
             if self._stop_tail.is_set():
                 break


### PR DESCRIPTION
**Description of the problem**

Being a containerized solution, we do not see the errors that might be happening at the server executed in Docker. 

**Proposed solution**

We already keep track of the tail of the server logs. Now, print them if the option '-d' or '--dump-server-output' has been passed as an argument to `launch_benchmark.py`.