### PR TITLE
Delete container based on name instead of served port

### DIFF
--- a/benchmark/inference_engine_client.py
+++ b/benchmark/inference_engine_client.py
@@ -18,6 +18,7 @@ class InferenceEngineClient:
         self.client = OpenAI(api_key=api_key, base_url=base_url, timeout=httpx.Timeout(60.0))
         self._launcher_proc = None
         self.model = None
+        self.NAME = "bench360_inference_engine"
 
     
 
@@ -41,7 +42,8 @@ class InferenceEngineClient:
         cmd = [
             script_path,
             f"--engine={backend}",
-            f"--model={model}"
+            f"--model={model}",
+            f"--name={self.NAME}"
         ]
         self._launcher_proc = subprocess.Popen(
             cmd,
@@ -176,25 +178,16 @@ class InferenceEngineClient:
 
     def close(self):
         """
-        Stop any Docker container exposing port 23333, terminate subprocess,
+        Stop Docker container, terminate subprocess,
         stop background log tailer (if running), and close HTTP client.
         """
         # 1) Attempt to find and stop the container(s) on port 23333
         try:
-            result = subprocess.run(
-                ["docker", "ps", "--filter", "publish=23333", "-q"],
-                stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
-                text=True,
-                check=True
+            subprocess.run(
+                ["docker", "stop", self.NAME],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL
             )
-            container_ids = result.stdout.strip().split()
-            for cid in container_ids:
-                subprocess.run(
-                    ["docker", "stop", cid],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL
-                )
         except subprocess.CalledProcessError:
             pass  # Docker might not be running
 

--- a/benchmark/launch_engine.sh
+++ b/benchmark/launch_engine.sh
@@ -3,13 +3,14 @@
 # launch_engine  —  Launch one of several LLM inference engines via Docker
 #
 # Usage:
-#   ./launch_engine --engine=<engine> --model=<model>
+#   ./launch_engine --engine=<engine> --model=<model> --name<name>
 #
 #   <engine> ∈ { tgi | vllm | mii | sglang | lmdeploy }
 #   <model>  is the Hugging Face model ID (e.g. “mistralai/Mistral-7B-Instruct-v0.3”)
+#   <name>   is the name for the container
 #
 # Example:
-#   ./launch_engine --engine=tgi --model=mistralai/Mistral-7B-Instruct-v0.3
+#   ./launch_engine --engine=tgi --model=mistralai/Mistral-7B-Instruct-v0.3 -name="bench360_inference_engine"
 #
 # Notes:
 #   • Expects HF_TOKEN or HUGGING_FACE_HUB_TOKEN in your environment.
@@ -30,17 +31,20 @@ for ARG in "$@"; do
     --model=*)
       MODEL="${ARG#--model=}"
       ;;
+    --name=*)
+      NAME="${ARG#--name=}"
+      ;;
     *)
       echo "Unknown argument: $ARG"
-      echo "Usage: $0 --engine=<tgi|vllm|mii|sglang|lmdeploy> --model=<your-org/your-model-name>"
+      echo "Usage: $0 --engine=<tgi|vllm|mii|sglang|lmdeploy> --model=<your-org/your-model-name> --name=<container-name>"
       exit 1
       ;;
   esac
 done
 
-if [[ -z "$ENGINE" || -z "$MODEL" ]]; then
-  echo "Error: both --engine and --model must be provided."
-  echo "Usage: $0 --engine=<tgi|vllm|mii|sglang|lmdeploy> --model=<your-org/your-model-name>"
+if [[ -z "$ENGINE" || -z "$MODEL" || -z "$NAME" ]]; then
+  echo "Error: All --engine, --model and --name must be provided."
+  echo "Usage: $0 --engine=<tgi|vllm|mii|sglang|lmdeploy> --model=<your-org/your-model-name> --name=<container-name>"
   exit 1
 fi
 
@@ -63,6 +67,7 @@ case "$ENGINE" in
     #
     # docker run --rm \
     #   --gpus all \
+    #   --name $NAME \
     #   -v "$HOME/.cache/huggingface:/data" \
     #   -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
     #   -e HF_TOKEN="$HF_TOKEN" \
@@ -75,6 +80,7 @@ case "$ENGINE" in
     # ────────────────────────────────────────────────────────────────────────
     docker run --rm \
       --gpus all \
+      --name $NAME \
       -v "$HOME/.cache/huggingface:/data" \
       -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
       -e HF_TOKEN="$HF_TOKEN" \
@@ -92,6 +98,7 @@ case "$ENGINE" in
     #
     # docker run --rm \
     #   --runtime=nvidia --gpus all \
+    #   --name $NAME \
     #   -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
     #   -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
     #   -p 127.0.0.1:23333:23333 \
@@ -104,6 +111,7 @@ case "$ENGINE" in
     # ────────────────────────────────────────────────────────────────────────
     docker run --rm \
       --runtime=nvidia --gpus all \
+      --name $NAME \
       -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
       -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
       -p 127.0.0.1:${PORT}:${PORT} \
@@ -121,6 +129,7 @@ case "$ENGINE" in
     #
     # docker run --rm \
     #   --runtime=nvidia --gpus all \
+    #   --name $NAME \
     #   -v $HOME/.cache/huggingface:/root/.cache/huggingface \
     #   -e HUGGING_FACE_HUB_TOKEN=$HF_TOKEN \
     #   -p 127.0.0.1:23333:23333 \
@@ -131,6 +140,7 @@ case "$ENGINE" in
     # ────────────────────────────────────────────────────────────────────────
     docker run --rm \
       --runtime=nvidia --gpus all \
+      --name $NAME \
       -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
       -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
       -p 127.0.0.1:${PORT}:${PORT} \
@@ -146,6 +156,7 @@ case "$ENGINE" in
     # SGLang (Slim Graph Language) container:
     #
     # docker run --gpus all \
+    #   --name $NAME \
     #   -p 127.0.0.1:23333:23333 \
     #   -v ~/.cache/huggingface:/root/.cache/huggingface \
     #   --ipc=host \
@@ -161,6 +172,7 @@ case "$ENGINE" in
     # ────────────────────────────────────────────────────────────────────────
     docker run --rm \
       --gpus all \
+      --name $NAME \
       -p 127.0.0.1:${PORT}:${PORT} \
       -v ~/.cache/huggingface:/root/.cache/huggingface \
       --ipc=host \
@@ -180,6 +192,7 @@ case "$ENGINE" in
     # DeepSpeed-MII container:
     #
     # docker run --runtime=nvidia --gpus all \
+    #   --name $NAME \
     #   -v $HOME/.cache/huggingface:/root/.cache/huggingface \
     #   -e HUGGING_FACE_HUB_TOKEN=$HF_TOKEN \
     #   -p 127.0.0.1:23333:23333 \
@@ -190,6 +203,7 @@ case "$ENGINE" in
     # ────────────────────────────────────────────────────────────────────────
     docker run --rm \
       --runtime=nvidia --gpus all \
+      --name $NAME \
       -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
       -e HUGGING_FACE_HUB_TOKEN="$HF_TOKEN" \
       -p 127.0.0.1:${PORT}:${PORT} \


### PR DESCRIPTION
**Description of the problem**

Currently created containers are stopped and removed by checking if they are serving port `23333`. However, if the container is launched using `--network=host`, such port is no longer visible to Docker, which results on having dangling unstopped containers running in the background,  occupying the resources and eventually exhausting them, preventing new containers from being created.

**Proposed solution**

Being a local benchmark suite, all benchmarks run sequentially to prevent resource contention. Therefore, one can assign a fixed name to the current running container and use such name to stop the container during cleanup. This way we make sure the exact container used is stopped and hence deleted. 

_NOTE: For future work when the suite could be launching different benchmarks in parallel, better use some unique identifier for each container._

