### PR TITLE
Add option for a custom launch engine Bash script

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -51,10 +51,9 @@ class ModelBenchmark:
         top_p: float = 0.95,
         max_tokens: int = 128,
         verbose=False,
-        dump_server_output: bool = False
+        dump_server_output: bool = False,
+        script_path: str = None
     ):
-        if backend not in ("tgi", "mii", "sglang", "vllm", "lmdeploy"):
-            raise ValueError(f"Unsupported backend: {backend}. Supported backends are: tgi, mii, sglang, vllm, lmdeploy.")
         self.backend = backend
         self.model_path = model_path
         self.model_name = model_name
@@ -62,6 +61,7 @@ class ModelBenchmark:
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.verbose = verbose
         self.dump_server_output = dump_server_output
+        self.script_path = script_path
         self.iec = InferenceEngineClient()
         self.api = HfApi()
         self.temperature = temperature
@@ -238,7 +238,7 @@ class ModelBenchmark:
 
         # ── First launch: cold start ──────────────────────────────
         t0 = time.time()
-        self.iec.launch(backend=self.backend, model=self.model_path, dump_server_output=self.dump_server_output)
+        self.iec.launch(backend=self.backend, model=self.model_path, dump_server_output=self.dump_server_output, script_path=self.script_path)
         startup = time.time() - t0
 
         # optional warm-up

--- a/benchmark/inference_engine_client.py
+++ b/benchmark/inference_engine_client.py
@@ -22,7 +22,7 @@ class InferenceEngineClient:
 
     
 
-    def launch(self, backend: str, model: str, timeout: float = 500.0, dump_server_output: bool = False):
+    def launch(self, backend: str, model: str, timeout: float = 500.0, dump_server_output: bool = False, script_path: str = None):
         """
         1) Starts your existing launch_engine.sh in a Popen (non-blocking).
         2) Polls `http://127.0.0.1:23333/v1/models` every 2 seconds
@@ -32,7 +32,8 @@ class InferenceEngineClient:
         :param model: HF model ID or local path
         :param timeout: Max seconds to wait for the model to appear before raising.
         """
-        script_path = os.path.join(os.getcwd(), "benchmark/launch_engine.sh")
+        if script_path is None:
+            script_path = os.path.join(os.getcwd(), "benchmark/launch_engine.sh")
         if not os.path.isfile(script_path):
             raise FileNotFoundError(f"Cannot find '{script_path}'.")
         if not os.access(script_path, os.X_OK):


### PR DESCRIPTION
**Description of the problem**

The `launch_engine.sh` Bash script is great for typical out-of-the-box benchmarks of LLM engines. However, the script cannot deal with configurations like network and proxy settings, or enabling tensor parallelism for a particular engine. Trying to generalize all possible scenarios is an unfeasible task.

**Proposed solution**

- Allow to pass a custom Bash script with the desired configuration and use the original script only if no custom script was specified.
- Remove the "unsupported backend" error from the python script, as such support depends only on the Bash script that is passed.
